### PR TITLE
Close button capture az

### DIFF
--- a/server/routes/message.router.js
+++ b/server/routes/message.router.js
@@ -6,7 +6,7 @@ const router = express.Router();
  * POST route template
  */
 router.post('/session', (req, res) => {
-  console.log('MADE IT TO MESSAGE PUT', req.body);
+  // console.log('MADE IT TO MESSAGE PUT', req.body);
   const query = `INSERT INTO "message_session" ("exam_id", "created_by")
                    VALUES ($1, $2)
                    RETURNING "id";`;
@@ -45,7 +45,7 @@ router.post('/session', (req, res) => {
 });
 
 router.post('/detail', (req, res) => {
-  console.log('MADE IT TO MESSAGE DETAIL PUT', req.body);
+  // console.log('MADE IT TO MESSAGE DETAIL PUT', req.body);
   const query = `INSERT INTO "message_detail" ("message_session_id", "creator_id", "message")
                    VALUES ($1, $2, $3)
                    RETURNING "id";`;

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -340,3 +340,8 @@ label:focus,
 .width50px {
   width: 50px;
 }
+
+.linkText {
+  text-decoration: underline;
+  color: #1E2A49;
+}

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -335,6 +335,8 @@ label:focus,
   justify-content: flex-end;
   align-content: stretch;
   align-items: flex-start;
+
+  width: 100%;
 }
 
 .width50px {

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -322,3 +322,17 @@ label:focus,
 .marginSides3 {
   margin: 0 3px;
 }
+
+.upperRhCornerParent {
+  display: flex;
+  justify-content: flex-end;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  align-content: stretch;
+  align-items: flex-start;
+}
+
+.width50px {
+  width: 50px;
+}

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -174,6 +174,10 @@ label:focus,
   height: 100px;
 }
 
+.a50pxSpacer {
+  height: 50px;
+}
+
 .buttonInsideInput {
   margin-left: -70px !important;
   width: 10px !important;

--- a/src/components/Compare/Compare.jsx
+++ b/src/components/Compare/Compare.jsx
@@ -3,6 +3,7 @@ import {useSelector, useDispatch} from 'react-redux';
 import './Compare.css'
 import { Button } from '@mui/material';
 import { Link, useHistory } from 'react-router-dom';
+import CancelIcon from '@mui/icons-material/Cancel';
 
 
 // Basic functional component structure for React with default state
@@ -15,7 +16,7 @@ function compareFunction(props) {
   const dispatch = useDispatch()
   const [photoToCompare, setPhotoToCompare] = useState('/images/profile_default.png')
   const [idToCompare, setIdToCompare] = useState('/images/profile_default.png')
-  const [heading, setHeading] = useState('Compare Images');
+  const [heading, setHeading] = useState("Please Verify Student's ID");
 
   useEffect( () => {
     getPhotoToCompare()
@@ -140,11 +141,19 @@ function compareFunction(props) {
     })
   }
 
+  const closeButton = () => {
+    props.onClickClose();
+  }
+
   return (
     <>
+      <div className="upperRhCornerParent">
+        <div className="width50px"></div>
+        <CancelIcon fontSize="large" onClick={closeButton}/>
+      </div>  
+
       <h2 className='heading'>{heading}</h2>
       {/* <p>{JSON.stringify(store.exam.selected)}</p> */}
-      <p>Please verify this student's ID</p>
 
       <div className="flexParent">
         <img src={photoToCompare} className='compareImage' />

--- a/src/components/Compare/Compare.jsx
+++ b/src/components/Compare/Compare.jsx
@@ -148,7 +148,6 @@ function compareFunction(props) {
   return (
     <>
       <div className="upperRhCornerParent">
-        <div className="width50px"></div>
         <CancelIcon fontSize="large" onClick={closeButton}/>
       </div>  
 

--- a/src/components/ExamTable/ExamTable.jsx
+++ b/src/components/ExamTable/ExamTable.jsx
@@ -101,7 +101,9 @@ function ExamTable(props) {
         className="compareModal flexParentVertical"
         hideBackdrop={true}
       >
-        <Compare />
+        <Compare 
+          onClickClose={ ()=>setShowCompareModal(false) } 
+        />
       </Modal>
 
     <TableContainer sx={{ minWidth: 500, maxWidth: 1200}} component={Paper}>
@@ -200,10 +202,10 @@ function ExamTable(props) {
             }
 
           {/* ==== INCIDENT ===================== */}
-              { mode === 'IN PROGRESS' || mode === 'COMPLETE'
+              {/* { mode === 'IN PROGRESS' || mode === 'COMPLETE'
               ? <TableCell align="center">{ !row.incident ? 0 : row.incident }</TableCell>
               : <></>
-              }
+              } */}
 
           {/* ==== ACTION BUTTON ===================== */}       
               <TableCell>

--- a/src/components/ExamTable/ExamTable.jsx
+++ b/src/components/ExamTable/ExamTable.jsx
@@ -27,9 +27,9 @@ function ExamTable(props) {
 
   const headers = 
       mode === "COMPLETE"  
-    ?   ['', 'FIRST NAME', 'LAST NAME', 'EMAIL/USERNAME', 'ID MATCH?', 'EXAM START', 'EXAM END', '# INCIDENTS', 'ACTION']
+    ?   ['', 'FIRST NAME', 'LAST NAME', 'EMAIL/USERNAME', 'ID MATCH?', 'EXAM START', 'EXAM END', 'ACTION']
     : mode === "IN PROGRESS" 
-    ?   ['', 'FIRST NAME', 'LAST NAME', 'EMAIL/USERNAME', 'ID MATCH?', 'ASSISTANCE', 'EXAM START', 'EXAM END', '# INCIDENTS', 'GO IN']
+    ?   ['', 'FIRST NAME', 'LAST NAME', 'EMAIL/USERNAME', 'ID MATCH?', 'ASSISTANCE', 'EXAM START', 'EXAM END', 'GO IN']
     : mode === "UPCOMING"
     ?   ['', 'FIRST NAME', 'LAST NAME', 'EMAIL/USERNAME', 'ACTION']
     :   [];

--- a/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
+++ b/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
@@ -64,8 +64,10 @@ function ProctorExamPageComplete(props) {
       <p>{exam.test_title} - {prettyEventDate} - {prettyEventTime}</p>
       <p>{exam.first_name} {exam.last_name} - {exam.username}</p>
       
-      <TableContainer component={Paper}>
-        <Table sx={{ maxWidth: 650 }} aria-label="simple table">
+      <br/>
+
+      <TableContainer component={Paper} sx={{ maxWidth: 500 }}>
+        <Table  aria-label="simple table">
 
           <TableBody>
 
@@ -131,6 +133,8 @@ function ProctorExamPageComplete(props) {
 
         </Table>
       </TableContainer>
+
+      <div className="a50pxSpacer"></div>
 
       {   exam.exam_status === "APPROVED"
         ? <>

--- a/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
+++ b/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
@@ -1,4 +1,4 @@
-import { Button, easing, Modal, Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
+import { Box, Button, easing, Modal, Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {useSelector} from 'react-redux';
@@ -43,13 +43,21 @@ function ProctorExamPageComplete(props) {
 
   return (
     <>
+      <Box 
+        sx={{
+          marginRight: "35px",
+          marginLeft: "35px"
+        }}
+      >
       <Modal 
         open={showCompareModal} 
         onClose={ ()=>setShowCompareModal(false) } 
         className="compareModal flexParentVertical"
         hideBackdrop={true}
       >
-        <Compare />
+        <Compare 
+          onClickClose={ ()=>setShowCompareModal(false) } 
+        />
       </Modal>
 
       <h2 className='heading'>EXAM RESULTS</h2>
@@ -140,7 +148,7 @@ function ProctorExamPageComplete(props) {
             <Button variant="contained" onClick={approveExam}>APPROVE RESULTS</Button>
           </>
       }          
-
+    </Box>
     </>
   );
 }

--- a/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
+++ b/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
@@ -76,10 +76,10 @@ function ProctorExamPageComplete(props) {
               <TableCell align="right">{exam.score || 0}</TableCell>
             </TableRow> 
 
-            <TableRow sx={{ '&:last-child td, &:last-child th': {border: 0} }}>
+            {/* <TableRow sx={{ '&:last-child td, &:last-child th': {border: 0} }}>
               <TableCell component="th" scope="row"># INCIDENTS</TableCell>
               <TableCell align="right">{exam.incident || 0}</TableCell>
-            </TableRow> 
+            </TableRow>  */}
 
             <TableRow sx={{ '&:last-child td, &:last-child th': {border: 0} }}>
               <TableCell component="th" scope="row">ID MATCH?</TableCell>

--- a/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
+++ b/src/components/ProctorExamPageComplete/ProctorExamPageComplete.jsx
@@ -11,6 +11,7 @@ import Compare from '../Compare/Compare';
 function ProctorExamPageComplete(props) {
   const exam = useSelector(store => store.exam.selected);
   const [showCompareModal, setShowCompareModal] = useState(false);
+  const [editApprovedRejected, setEditApprovedRejected] = useState(false);
   const dispatch = useDispatch();
 
   const formatDate = (dateString) => {
@@ -31,6 +32,10 @@ function ProctorExamPageComplete(props) {
 
   const rejectExam = () => {
     dispatch({ type:'REJECT_EXAM', payload: {exam_id: exam.exam_id} })
+  }
+  
+  const updateExamToAwaitingApproval = () => {
+    dispatch({ type:'UPDATE_EXAM_AWAITING_APPROVAL', payload: {exam_id: exam.exam_id} })
   }
 
   const passExam = () => {
@@ -135,23 +140,24 @@ function ProctorExamPageComplete(props) {
       </TableContainer>
 
       <div className="a50pxSpacer"></div>
-
-      {   exam.exam_status === "APPROVED"
+      {
+          exam.exam_status === "APPROVED"
         ? <>
             <p>Exam Approved</p>
-            <Button variant="outlined" onClick={rejectExam}>REJECT RESULTS</Button>
+            <p className="linkText" onClick={updateExamToAwaitingApproval}>Undo Approval</p>
           </>
         : exam.exam_status === "REJECTED"
         ? <>
             <p>Exam Rejected</p>
-            <Button variant="outlined" onClick={approveExam}>APPROVE RESULTS</Button>
+            <p className="linkText" onClick={updateExamToAwaitingApproval}>Undo Rejection</p>
           </>
-        : <>
+        : <> 
+          {/* else if awaiting approval */}
             <p>Awaiting Approval</p>
             <Button variant="outlined" onClick={rejectExam}>REJECT RESULTS</Button>
             <Button variant="contained" onClick={approveExam}>APPROVE RESULTS</Button>
           </>
-      }          
+      }    
     </Box>
     </>
   );

--- a/src/components/ProctorExamPageInProgress/ProctorExamPageInProgress.jsx
+++ b/src/components/ProctorExamPageInProgress/ProctorExamPageInProgress.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 import {Button, Card, CardContent, Typography } from '@mui/material'; 
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
-import IncidentCounter from '../IncidentCounter/IncidentCounter';
+// import IncidentCounter from '../IncidentCounter/IncidentCounter';
 import { useHistory } from 'react-router-dom';
 import MessageSession from '../Chat/MessageSession'
 import ImageDisplay from '../ImageDisplay/ImageDisplay';
@@ -87,7 +87,8 @@ function ProctorExamPageInProgress() {
 
       </div>
 
-      <IncidentCounter exam={exam}/>
+
+      {/* <IncidentCounter exam={exam}/> */}
 
       <br/>
       <Button variant="contained" onClick={doneHelping}>DONE ASSISTING</Button>

--- a/src/components/QuestionList/QuestionList.jsx
+++ b/src/components/QuestionList/QuestionList.jsx
@@ -37,7 +37,6 @@ function QuestionList(props) {
 
   const closeModal=()=>{
     setShowModal(false); 
-    console.log('closeModal running', showModal); 
   }
 
   const addQuestionAboutButterflies = () => {

--- a/src/components/StudentExamPageComplete/StudentExamPageComplete.jsx
+++ b/src/components/StudentExamPageComplete/StudentExamPageComplete.jsx
@@ -47,11 +47,11 @@ function studentExamPageComplete(props) {
               <TableCell component="th" scope="row"># CORRECT</TableCell>
               <TableCell align="right">{exam.score || 0}</TableCell>
             </TableRow> 
-
+{/* 
             <TableRow sx={{ '&:last-child td, &:last-child th': {border: 0} }}>
               <TableCell component="th" scope="row"># INCIDENTS</TableCell>
               <TableCell align="right">{exam.incident || 0}</TableCell>
-            </TableRow> 
+            </TableRow>  */}
 
             <TableRow sx={{ '&:last-child td, &:last-child th': {border: 0} }}>
               <TableCell component="th" scope="row">PASS/FAIL</TableCell>

--- a/src/components/StudentExamPageComplete/StudentExamPageComplete.jsx
+++ b/src/components/StudentExamPageComplete/StudentExamPageComplete.jsx
@@ -1,4 +1,4 @@
-import { Button, easing, Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
+import { Box, Button, easing, Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {useSelector} from 'react-redux';
@@ -23,13 +23,18 @@ function studentExamPageComplete(props) {
 
 
   return (
-    <div>
+      <Box 
+        sx={{
+          marginRight: "35px",
+          marginLeft: "35px"
+        }}
+      >
       <h2>EXAM RESULTS</h2>
-      <h2>{exam.test_title} - {prettyEventDate} - {prettyEventTime}</h2>
-      <h2>{exam.first_name} {exam.last_name} - {exam.username}</h2>
+      <p>{exam.test_title} - {prettyEventDate} - {prettyEventTime}</p>
+      <p>{exam.first_name} {exam.last_name} - {exam.username}</p>
       
-      <TableContainer component={Paper}>
-        <Table sx={{ maxWidth: 650 }} aria-label="simple table">
+      <TableContainer component={Paper} sx={{ maxWidth: 500 }} >
+        <Table aria-label="simple table">
 
           <TableBody>
 
@@ -67,8 +72,7 @@ function studentExamPageComplete(props) {
 
         </Table>
       </TableContainer>        
-     
-    </div>
+    </Box>
   );
 }
 

--- a/src/redux/sagas/exam.saga.js
+++ b/src/redux/sagas/exam.saga.js
@@ -13,24 +13,32 @@ function* eventSaga() {
   yield takeLatest('UPDATE_ACTIVE_EXAM_QUESTION', updateActiveExamQuestion);//update exam with students active question id.
   yield takeLatest('CAPTURE_ANSWER', captureAnswer);//updates exam_detail record with answer and graded outcome.
   yield takeLatest('SCORE_EXAM', scoreExam);
+ 
   yield takeLatest('ACCEPT_TERMS', acceptTerms);
   //dispatch({ type: 'FETCH_SELECTED_EXAM', payload: {exam_id: putSomethingHere} }); 
+  
   yield takeLatest('APPROVE_EXAM', approveExam);
   //dispatch({ type:'APPROVE_EXAM', payload: {exam_id: exam.exam_id} })
   yield takeLatest('REJECT_EXAM', rejectExam);
   //dispatch({ type:'REJECT_EXAM', payload: {exam_id: exam.exam_id} })
+  yield takeLatest('UPDATE_EXAM_AWAITING_APPROVAL', updateExamAwaitingApproval);
+  //dispatch({ type:'UPDATE_EXAM_AWAITING_APPROVAL', payload: {exam_id: exam.exam_id} });
+
   yield takeLatest('PASS_EXAM', passExam);
   //dispatch({ type:'PASS_EXAM', payload: {exam_id: exam.exam_id} })
   yield takeLatest('FAIL_EXAM', failExam);
   //dispatch({ type:'FAIL_EXAM', payload: {exam_id: exam.exam_id} })
+ 
   yield takeLatest('FETCH_EXAM_QUESTION_PROCTOR', fetchExamQuestionProctor);
   //dispatch({ type:'FETCH_EXAM_QUESTION_PROCTOR', payload: {exam_id: exam.id} });
+  
   yield takeLatest('ADD_INCIDENT', addIncident);
   //dispatch({ type:'ADD_INCIDENT', payload: {exam_detail: exam_detail} });
   yield takeLatest('CHANGE_HELP_STATUS', changeHelpStatus);
   //dispatch({ type:'CHANGE_HELP_STATUS', payload: {help: value} });
 
 }
+
 
 // worker Saga: will be fired on "CHANGE_HELP_STATUS" actions
 function* changeHelpStatus(action) {
@@ -274,6 +282,20 @@ function* rejectExam(action) {
     console.log('update exam failed', error);
   }
 }
+
+// worker Saga: will be fired on "UPDATE_EXAM_AWAITING_APPROVAL" actions
+function* updateExamAwaitingApproval(action) {
+  const ap = action.payload;
+  //ap.exam_id
+  try {
+    yield axios.put(`/api/exam/status/${ap.exam_id}`, { status: "AWAITING APPROVAL" });
+    yield put({ type: 'SET-UPDATE_SELECTED_EXAM', payload: { exam_status: "AWAITING APPROVAL" } });
+  } catch (error) {
+    console.log('update exam failed', error);
+  }
+}
+
+
 
 
 


### PR DESCRIPTION
- confirmed incident CRUD works
- but then ultimately commented out all instances of "incident" from view, for the presentation/this phase of the app
- refactored approve/reject exam experience to be more like an "undo"
- added padding to exam results page (student and proctor views)
- adjusted table styling to ^these pages too
- added a cancel button to the "compare" modal, and moved it to upper RH corner